### PR TITLE
Update tcp.c

### DIFF
--- a/drivers/network/tcpip/ip/transport/tcp/tcp.c
+++ b/drivers/network/tcpip/ip/transport/tcp/tcp.c
@@ -411,6 +411,16 @@ NTSTATUS TCPConnect
                                                 &connaddr,
                                                 RemotePort));
 
+    if ((Status != STATUS_SUCCESS) && (Status != STATUS_PENDING)) { 
+    	TI_DbgPrint(DEBUG_TCP,
+                    ("no pcb from LibTCPConnect, clear ConnectRequest.\n")); 
+    	LockObject(Connection);
+    	RemoveTailList( &Connection->ConnectRequest); 
+	    // DLB - re-check, not sure this part is correct
+	    ExFreeToNPagedLookasideList( &TdiBucketLookasideList, Bucket );
+    	UnlockObject(Connection);
+    }
+
     TI_DbgPrint(DEBUG_TCP,("[IP, TCPConnect] Leaving. Status = 0x%x\n", Status));
 
     return Status;


### PR DESCRIPTION
Prevent BSOD [CORE-18982]

## Purpose

Early failures calling LibTCPConnect return without initializing a pcb, as a result later references to the pcb from the Connection request will cause a BSOD. 

JIRA issue: [CORE-18982](https://jira.reactos.org/browse/CORE-18982)

## Proposed changes

This change clears out the connection request immediately after returning from LibTCPConnect for those early failure cases.
